### PR TITLE
Allow class attribute to be set for modal buttons

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -47,7 +47,8 @@
                         <button v-for="(btn, index) in buttons"
                             :key="index"
                             @click="handleButtonClick(btn)"
-                            v-text="btn.text">
+                            v-text="btn.text"
+                            v-bind:class="btn.class">
                         </button>
                     </slot>
                 </div>


### PR DESCRIPTION
Added class binding to modal button, to allow custom classes to be set for buttons. eg. To allow for button colours.