### PR TITLE
Allow specifying button type attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ text | String | '' | yes | The text of the button
 handler | function | undefined | no | The function which will be called on button press. The default action is to hide the modal, so you don't have to include anything if the button click should only close the modal.
 preventDefault | Boolean | undefined (false) | no | Even if you provide a handler, the modal will be closed after the action is done. To prevent that set this property to true.
 class | String | '' | no | Additional CSS class(es) to add to the button.
+type | String | '' | no | Button type (submit|reset|button). eg. Specify 'button' to prevent automatic form submission.
 
 #### Ajax
 

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -48,6 +48,7 @@
                             :key="index"
                             @click="handleButtonClick(btn)"
                             v-text="btn.text ? btn.text : ''"
+                            :type="btn.type ? btn.type : ''"
                             :class="btn.class ? btn.class : ''">
                         </button>
                     </slot>


### PR DESCRIPTION
When using the modal in my form, the form always gets submitted after clicking the modal buttons, because the default type of buttons is 'submit'. That behaviour is unwanted sometimes. Allowing the button type attribute to be set to 'button' avoids the default submit and lets us use JS to do the form submit, etc. 